### PR TITLE
feat!: upgrade quinn to 0.8

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,8 @@ name: PR
 on: pull_request
 
 env:
-  # Run all cargo commands with --verbose.
   CARGO_TERM_VERBOSE: true
   RUST_BACKTRACE: 1
-  # Deny all compiler warnings.
   RUSTFLAGS: "-D warnings"
 
 jobs:
@@ -21,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -29,7 +26,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -39,11 +35,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Check if the code is formatted correctly.
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      # Run Clippy.
       - name: Clippy checks
         run: cargo clippy --all-targets
 
@@ -67,14 +61,12 @@ jobs:
       PROPTEST_CASES: 1
     steps:
       - uses: actions/checkout@v2
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -84,7 +76,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
 
-      # Run cargo tarpaulin & push result to coveralls.io
       - name: rust-tarpaulin code coverage check
         uses: actions-rs/tarpaulin@v0.1
         with:
@@ -107,7 +98,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -125,7 +115,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # wget the shared deny.toml file from the QA repo
     - shell: bash
       run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
 
@@ -140,14 +129,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
 
-      # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
         with:
@@ -157,20 +144,21 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
       
-      # Run tests.
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --release
 
-  # Test publish using --dry-run.
+      - name: run ping example as integration test
+        shell: bash
+        run: cargo run --example ping
+
   test-publish:
     if: "!startsWith(github.event.pull_request.title, 'Automated version bump')"
     name: Test Publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,22 @@ name = "ping"
 [dependencies]
 futures = "~0.3"
 log = "~0.4"
+quinn = { version = "0.8.0", default-features = false, features = ["tls-rustls", "ring"] }
+quinn-proto = "0.8.0"
 rand = "~0.7"
 rcgen = "~0.7"
+rustls = { version = "0.20.2", default-features = false, features = ["quic", "dangerous_configuration"] }
 serde_json = "1.0.62"
+thiserror = "1.0.23"
 url = "2.2.0"
+webpki = "~0.21.3"
 
-  [dependencies.serde]
-  version = "1.0.123"
-  features = [ "derive" ]
-
-  [dependencies.quinn]
-  version = "~0.7"
-  features = [ "tls-rustls" ]
-  default-features = false
+[dependencies.serde]
+version = "1.0.123"
+features = [ "derive" ]
 
 [dev-dependencies]
+assert_fs = "~1.0"
+color-eyre = "~0.6"
+tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
-
-  [dev-dependencies.tokio]
-  version = "1.3.0"
-  features = [ "rt", "macros" ]

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -129,7 +129,7 @@ where
     let res_payload = std::str::from_utf8(response_bytes)
         .map_err(|err| Error::ClientError(format!("Failed to decode response data: {}", err)))?;
 
-    match serde_json::from_str(&res_payload) {
+    match serde_json::from_str(res_payload) {
         Ok(JsonRpcResponse {
             jsonrpc,
             result: Some(r),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,20 @@ mod jsonrpc;
 mod server_endpoint;
 mod utils;
 
-const ALPN_QUIC_HTTP: &[&[u8]] = &[b"hq-24"];
+use std::time::Duration;
+
+const ALPN_QUIC_HTTP: &[u8] = b"hq-24";
+
+/// Default idle timeout for endpoint transfer config.
+///
+/// Ostensibly a little inside the 20s that a lot of routers might cut off at.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(18);
 
 pub use client_endpoint::ClientEndpoint;
 pub use errors::{Error, Result};
-pub use server_endpoint::{Endpoint, IncomingConn, IncomingJsonRpcRequest, JsonRpcResponseStream};
+pub use server_endpoint::{
+    IncomingConn, IncomingJsonRpcRequest, JsonRpcResponseStream, ServerEndpoint,
+};
 
 pub use jsonrpc::{
     JsonRpcRequest, JsonRpcResponse, JSONRPC_INTERNAL_ERROR, JSONRPC_INVALID_PARAMS,


### PR DESCRIPTION
Use the new version of the `quinn` crate, which has a different API. Constructing and configuring
endpoints was changed, with some of the functionality even moving to the `rustls` crate, which is
also upgraded here to the latest version.

BREAKING CHANGE: the API for `ServerEndpoint` and `ClientEndpoint` have both changed to construct
instances by providing paths to certificates and keys, rather than a directory containing them. To
me, for a generic library, it makes more sense for the caller to provide certs and keys from
wherever they wanted to and not constrain them to using DER certificates with a particular file
name. This change also places responsibility on the caller to generate self-signed certificates,
which I would argue should probably be done in the Safe CLI and Auth processes, not even in
`sn_api`.

Some additional functionality was added to validate the provided certificate.

Unit tests were added for both these structs where possible, though things were made difficult by
the `quinn` and `rustls` crates, since they hide information after it's been set. For more info, see
my doc comments on `ClientEndpoint`.

I added the `ping` example to CI for integration testing the code that requires a real connection.
It may have been possible to unit test this code by creating a trait to implement a fake connection,
but I decided that was excessive for a small library.
