### PR TITLE
feat!: return result rather than option for connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ webpki = "~0.21.3"
 assert_fs = "~1.0"
 color-eyre = "~0.6"
 tempfile = "3"
-
-  [dev-dependencies.tokio]
-  version = "1.17.0"
-  features = [ "macros", "rt-multi-thread" ]
+tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"]  }
+tracing = "~0.1.26"
+tracing-subscriber = "~0.2.15"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,20 +7,28 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+use crate::{JsonRpcResponse, JsonRpcResponseStream};
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("ClientError: {0}")]
     ClientError(String),
-    #[error("ServerError: {0}")]
-    ServerError(String),
-    #[error("RemoteEndpointError: {0}")]
-    RemoteEndpointError(String),
-    #[error("GeneralError: {0}")]
-    GeneralError(String),
     #[error("An error occurred configuring crypto options")]
     CryptoConfigError(#[from] rustls::Error),
+    #[error("GeneralError: {0}")]
+    GeneralError(String),
     #[error("An error occurred parsing idle timeout for transport config")]
     IdleTimeoutParsingError(#[from] quinn_proto::VarIntBoundsExceeded),
+    /// For use when there's a problem parsing a request that was sent to the server.
+    ///
+    /// The response object will indicate the problem and the stream can be used to send it back to
+    /// the client.
+    #[error("An error occurred while parsing incoming JSON-RPC request")]
+    JsonRpcRequestParsingError(JsonRpcResponse, JsonRpcResponseStream),
+    #[error("RemoteEndpointError: {0}")]
+    RemoteEndpointError(String),
+    #[error("ServerError: {0}")]
+    ServerError(String),
     #[error("An error occurred configuring client to use certificates")]
     Webpki(#[from] webpki::Error),
 }


### PR DESCRIPTION
BREAKING CHANGE: we will now return `Result` rather than `Option` for managing connections and
incoming requests.

In the previous setup, the `get_next` function on `IncomingJsonRpcRequest` returned an `Option`
rather than a `Result`. The problem with this is it was swallowing some errors that would be
relevant to return back to the client, such as when the client's request couldn't be parsed by the
server. This change does make things a bit more clunky for the caller of `get_next`: you have to
`match` on a `Result` then unwrap an `Option`, rather than just unwrapping the `Option` directly.
However, my view would be that correctness would be preferable to convenience in this case. It also
gives callers the ability to respond to certain errors rather than making that decision for them by
consuming the error and returning back `None`.

With this change in mind, a specific `JsonRpcRequestParsingError` was introduced that provides a
response and a stream to use to send the response back to the client, to indicate something went
wrong.

The same change was applied to `IncomingConn`, which was also swallowing errors and returning
`None`.

Some test coverage was added around the JSON parsing functions. It might perhaps be possible to add
some integration tests to get more coverage on the connection and request management, but for now,
at least some of it is covered by the ping example.

Finally, the changes for returning `Result` forced an update for the example. The request loop for
the example was removed because right now we can only send one request per connection. I've proposed
a change for that, but will deal with it in another commit.